### PR TITLE
feat(cm6): PR3 — MultiLineEditor

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch6/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch6/index.js
@@ -1,0 +1,366 @@
+import React, { useState, useEffect, useRef, useCallback, forwardRef } from 'react';
+import { IconRegex, IconArrowUp, IconArrowDown, IconX, IconLetterCase, IconLetterW, IconChevronRight, IconReplace, IconArrowsExchange2 } from '@tabler/icons';
+import ToolHint from 'components/ToolHint';
+import StyledWrapper from 'components/CodeMirrorSearch/StyledWrapper';
+import useDebounce from 'hooks/useDebounce';
+import { replaceSingle, replaceAll } from 'components/CodeMirrorSearch/replaceUtils';
+import { findSearchMatches, createCacheKey } from 'components/CodeMirrorSearch/searchUtils';
+import { markViewportMatches, clearMarks } from 'components/CodeMirrorSearch/markingUtils';
+import { useSearchBarHandle } from 'components/CodeMirrorSearch/useSearchBarHandle';
+import { createCm5Compat } from 'utils/codemirror6/compat';
+
+/**
+ * CM6 search bar — reuses CM5 search utils via compat shim.
+ */
+const CodeMirrorSearch6 = forwardRef(({ visible, view, readOnly, onClose }, ref) => {
+  const editor = view ? createCm5Compat(view) : null;
+
+  const [searchText, setSearchText] = useState('');
+  const [replaceText, setReplaceText] = useState('');
+  const [replaceVisible, setReplaceVisible] = useState(false);
+  const [regex, setRegex] = useState(false);
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [wholeWord, setWholeWord] = useState(false);
+  const [matchIndex, setMatchIndex] = useState(0);
+  const [matchCount, setMatchCount] = useState(0);
+
+  const searchMarks = useRef([]);
+  const searchLineHighlight = useRef(null);
+  const searchMatches = useRef([]);
+  const searchCacheKey = useRef('');
+  const currentMatchIndex = useRef(0);
+  const docVersion = useRef(0);
+  const inputRef = useRef(null);
+  const replaceInputRef = useRef(null);
+  const containerRef = useRef(null);
+  const initialIndexRef = useRef(null);
+  const pendingSearchIndexRef = useRef(null);
+  const rafRef = useRef(null);
+
+  const debouncedSearchText = useDebounce(searchText, 250);
+
+  const redrawMarks = useCallback(() => {
+    if (!editor) return;
+    markViewportMatches(editor, searchMatches.current, currentMatchIndex.current, searchMarks.current);
+  }, [editor]);
+
+  const doSearch = useCallback((text, newIndex = 0, preferLine = null, shouldScroll = false) => {
+    if (!editor || !visible) return;
+
+    if (searchLineHighlight.current !== null) {
+      editor.removeLineClass(searchLineHighlight.current, 'wrap', 'cm-search-line-highlight');
+      searchLineHighlight.current = null;
+    }
+
+    if (!text) {
+      setMatchCount(0);
+      setMatchIndex(0);
+      currentMatchIndex.current = 0;
+      searchMatches.current = [];
+      searchCacheKey.current = '';
+      clearMarks(searchMarks.current);
+      return;
+    }
+
+    try {
+      const newCacheKey = createCacheKey(docVersion.current, text, regex, caseSensitive, wholeWord);
+      const isCacheHit = newCacheKey === searchCacheKey.current;
+
+      let matches = searchMatches.current;
+      if (!isCacheHit) {
+        matches = findSearchMatches(editor, text, regex, caseSensitive, wholeWord);
+        searchMatches.current = matches;
+        searchCacheKey.current = newCacheKey;
+        setMatchCount(matches.length);
+
+        if (preferLine !== null && newIndex === 0) {
+          const nearestIdx = matches.findIndex((m) => m.from.line >= preferLine);
+          newIndex = nearestIdx >= 0 ? nearestIdx : 0;
+        }
+      }
+
+      if (!matches.length) {
+        setMatchIndex(0);
+        currentMatchIndex.current = 0;
+        clearMarks(searchMarks.current);
+        return;
+      }
+
+      const resolvedIndex = Math.max(0, Math.min(newIndex, matches.length - 1));
+      setMatchIndex(resolvedIndex);
+      currentMatchIndex.current = resolvedIndex;
+
+      redrawMarks();
+
+      const currentLine = matches[resolvedIndex].from.line;
+      editor.addLineClass(currentLine, 'wrap', 'cm-search-line-highlight');
+      searchLineHighlight.current = currentLine;
+
+      if (shouldScroll) {
+        editor.scrollIntoView(matches[resolvedIndex].from, 100);
+      }
+      editor.setSelection(matches[resolvedIndex].from, matches[resolvedIndex].to, { scroll: false });
+    } catch (e) {
+      console.error('Search error:', e);
+      setMatchCount(0);
+      setMatchIndex(0);
+      currentMatchIndex.current = 0;
+      searchMatches.current = [];
+      searchCacheKey.current = '';
+    }
+  }, [regex, caseSensitive, wholeWord, editor, visible, redrawMarks]);
+
+  const handleSearchBarClose = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    clearMarks(searchMarks.current);
+    if (searchLineHighlight.current !== null && editor) {
+      editor.removeLineClass(searchLineHighlight.current, 'wrap', 'cm-search-line-highlight');
+      searchLineHighlight.current = null;
+    }
+    searchMatches.current = [];
+    searchCacheKey.current = '';
+    currentMatchIndex.current = 0;
+    setReplaceVisible(false);
+    if (onClose) onClose();
+    if (editor) {
+      const cursor = editor.getCursor('from');
+      editor.setSelection(cursor, cursor, { scroll: false });
+      setTimeout(() => editor.focus(), 0);
+    }
+  }, [editor, onClose]);
+
+  useSearchBarHandle({
+    ref,
+    editor,
+    searchText,
+    regex,
+    caseSensitive,
+    wholeWord,
+    searchMatches,
+    searchCacheKey,
+    docVersion,
+    initialIndexRef,
+    inputRef,
+    replaceInputRef,
+    setSearchText,
+    setMatchCount,
+    setMatchIndex,
+    setReplaceVisible,
+    doSearch,
+    handleSearchBarClose
+  });
+
+  useEffect(() => {
+    if (initialIndexRef.current && debouncedSearchText !== initialIndexRef.current.forText) {
+      return;
+    }
+
+    if (initialIndexRef.current && initialIndexRef.current.forText === debouncedSearchText) {
+      const idx = initialIndexRef.current.idx;
+      initialIndexRef.current = null;
+      doSearch(debouncedSearchText, idx);
+    } else {
+      initialIndexRef.current = null;
+      const cursor = editor?.getCursor('from');
+      const cursorLine = cursor ? cursor.line : null;
+      doSearch(debouncedSearchText, 0, cursorLine);
+    }
+  }, [debouncedSearchText, doSearch, editor]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !visible) return;
+
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') handleSearchBarClose();
+    };
+
+    container.addEventListener('keydown', onKeyDown, true);
+    return () => container.removeEventListener('keydown', onKeyDown, true);
+  }, [visible, handleSearchBarClose]);
+
+  useEffect(() => {
+    if (!editor || !visible) return;
+
+    const handleScroll = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => redrawMarks());
+    };
+
+    editor.on('scroll', handleScroll);
+    return () => {
+      editor.off('scroll', handleScroll);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [editor, visible, redrawMarks]);
+
+  useEffect(() => {
+    if (!editor || !visible) return;
+
+    let timeoutId;
+    const handleChange = () => {
+      docVersion.current += 1;
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        searchCacheKey.current = '';
+        const idx = pendingSearchIndexRef.current ?? 0;
+        pendingSearchIndexRef.current = null;
+        doSearch(debouncedSearchText, idx);
+      }, 100);
+    };
+
+    editor.on('change', handleChange);
+    return () => {
+      editor.off('change', handleChange);
+      clearTimeout(timeoutId);
+    };
+  }, [editor, visible, doSearch, debouncedSearchText]);
+
+  const handleToggleRegex = () => {
+    setRegex((prev) => !prev);
+    setMatchIndex(0);
+  };
+
+  const handleToggleCase = () => {
+    setCaseSensitive((prev) => !prev);
+    setMatchIndex(0);
+  };
+
+  const handleToggleWholeWord = () => {
+    setWholeWord((prev) => !prev);
+    setMatchIndex(0);
+  };
+
+  const handleNext = () => {
+    if (isDebouncing || !searchMatches.current?.length) return;
+    const next = (matchIndex + 1) % searchMatches.current.length;
+    doSearch(debouncedSearchText, next, null, true);
+  };
+
+  const handlePrev = () => {
+    if (isDebouncing || !searchMatches.current?.length) return;
+    const prev = (matchIndex - 1 + searchMatches.current.length) % searchMatches.current.length;
+    doSearch(debouncedSearchText, prev, null, true);
+  };
+
+  const handleReplace = useCallback(() => {
+    if (!editor || !searchMatches.current.length || !searchMatches.current[matchIndex]) return;
+
+    const { endLine, endCh } = replaceSingle(editor, searchMatches.current, matchIndex, replaceText);
+
+    const newMatches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
+    searchMatches.current = newMatches;
+    searchCacheKey.current = createCacheKey(docVersion.current, debouncedSearchText, regex, caseSensitive, wholeWord);
+    setMatchCount(newMatches.length);
+
+    const nextIdx = newMatches.findIndex(
+      (m) => m.from.line > endLine || (m.from.line === endLine && m.from.ch >= endCh)
+    );
+    const resolvedNextIdx = nextIdx >= 0 ? nextIdx : 0;
+    pendingSearchIndexRef.current = resolvedNextIdx;
+    doSearch(debouncedSearchText, resolvedNextIdx, null, true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
+
+  const handleReplaceAll = useCallback(() => {
+    if (!editor || !searchMatches.current.length) return;
+
+    const allMatches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord, Infinity);
+    replaceAll(editor, allMatches, replaceText);
+
+    searchCacheKey.current = '';
+    doSearch(debouncedSearchText, 0);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [editor, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
+
+  const isDebouncing = searchText !== debouncedSearchText;
+  const isReplaceDisabled = isDebouncing || !searchText.trim() || matchCount === 0;
+
+  if (!visible) return null;
+
+  return (
+    <StyledWrapper $replaceVisible={replaceVisible}>
+      <div className="bruno-search-bar" ref={containerRef} data-testid="codemirror-search-bar">
+        <button
+          type="button"
+          className={`toggle-replace-btn${replaceVisible ? ' active' : ''}`}
+          title={replaceVisible ? 'Hide replace' : 'Show replace'}
+          onClick={() => setReplaceVisible((prev) => !prev)}
+          style={readOnly ? { display: 'none' } : {}}
+          data-testid="toggle-replace-btn"
+        >
+          <IconChevronRight
+            size={12}
+            style={{ transform: replaceVisible ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }}
+          />
+        </button>
+        <div className="search-replace-rows">
+          <div className="search-row">
+            <input
+              ref={inputRef}
+              autoFocus
+              type="text"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              placeholder="Search..."
+              spellCheck={false}
+              data-testid="codemirror-search-input"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && replaceVisible && !isReplaceDisabled) {
+                  e.preventDefault();
+                  handleReplaceAll();
+                } else if (e.key === 'Enter' && !e.shiftKey) {
+                  handleNext();
+                } else if (e.key === 'Enter' && e.shiftKey) {
+                  handlePrev();
+                }
+              }}
+            />
+            <span className="searchbar-result-count" data-testid="codemirror-search-result-count">{isDebouncing ? '...' : matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
+            <ToolHint text="Regex search" toolhintId="searchbar-regex-toolhint" place="top">
+              <button type="button" className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex} data-testid="codemirror-search-regex-btn"><IconRegex size={16} /></button>
+            </ToolHint>
+            <ToolHint text="Case sensitive" toolhintId="searchbar-case-toolhint" place="top">
+              <button type="button" className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase} data-testid="codemirror-search-case-btn"><IconLetterCase size={14} /></button>
+            </ToolHint>
+            <ToolHint text="Whole word" toolhintId="searchbar-wholeword-toolhint" place="top">
+              <button type="button" className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord} data-testid="codemirror-search-wholeword-btn"><IconLetterW size={14} /></button>
+            </ToolHint>
+            <button type="button" className="searchbar-icon-btn" title="Previous (Shift+Enter)" onClick={handlePrev} data-testid="codemirror-search-prev-btn"><IconArrowUp size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext} data-testid="codemirror-search-next-btn"><IconArrowDown size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose} data-testid="codemirror-search-close-btn"><IconX size={14} /></button>
+          </div>
+          {replaceVisible && !readOnly && (
+            <div className="replace-row">
+              <input
+                ref={replaceInputRef}
+                type="text"
+                value={replaceText}
+                onChange={(e) => setReplaceText(e.target.value)}
+                placeholder="Replace..."
+                spellCheck={false}
+                data-testid="codemirror-search-replace-input"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isReplaceDisabled) {
+                    e.preventDefault();
+                    handleReplaceAll();
+                  } else if (e.key === 'Enter' && !isReplaceDisabled) {
+                    handleReplace();
+                  }
+                }}
+              />
+              <ToolHint text="Replace" toolhintId="searchbar-replace-toolhint" place="top">
+                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplace} data-testid="codemirror-search-replace-btn"><IconReplace size={15} /></button>
+              </ToolHint>
+              <ToolHint text="Replace all" toolhintId="searchbar-replaceall-toolhint" place="top">
+                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplaceAll} data-testid="codemirror-search-replaceall-btn"><IconArrowsExchange2 size={15} /></button>
+              </ToolHint>
+            </div>
+          )}
+        </div>
+      </div>
+    </StyledWrapper>
+  );
+});
+
+export default CodeMirrorSearch6;

--- a/packages/bruno-app/src/components/CodeMirrorSearch6/searchKeyBindings.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch6/searchKeyBindings.js
@@ -1,0 +1,52 @@
+import { keymap } from '@codemirror/view';
+import { createCm5Compat } from 'utils/codemirror6/compat';
+
+/**
+ * CM6 search keybindings using compat shim for CodeMirrorSearch6.
+ */
+export function buildSearchKeyBindings6({ setState, searchBarRef, isSearchBarVisible, isReadOnly, viewRef }) {
+  const openSearch = () => {
+    const view = viewRef?.current;
+    if (!view) return;
+    const compat = createCm5Compat(view);
+    const selected = compat.getSelection();
+    const cursor = compat.getCursor('from');
+    setState({ searchBarVisible: true }, () => {
+      if (selected) {
+        searchBarRef.current?.setSearch(selected, cursor);
+      } else {
+        searchBarRef.current?.focusAtCursor(cursor);
+      }
+    });
+  };
+
+  const openReplace = () => {
+    if (isReadOnly()) return;
+    setState({ searchBarVisible: true }, () => {
+      searchBarRef.current?.focus();
+      searchBarRef.current?.openReplace();
+    });
+  };
+
+  return keymap.of([
+    { key: 'Mod-f', run: () => {
+      openSearch(); return true;
+    } },
+    { key: 'Ctrl-h', run: () => {
+      openReplace(); return true;
+    } },
+    { key: 'Mod-Alt-f', run: () => {
+      openReplace(); return true;
+    } },
+    {
+      key: 'Escape',
+      run: () => {
+        if (isSearchBarVisible()) {
+          searchBarRef.current?.close();
+          return true;
+        }
+        return false;
+      }
+    }
+  ]);
+}

--- a/packages/bruno-app/src/components/FileEditor/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FileEditor/CodeEditor/StyledWrapper.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
-  div.CodeMirror {
+  .bruno-cm6-editor .cm-editor {
     height: 100%;
     background: ${(props) => props.theme.codemirror.bg};
     border: solid 1px ${(props) => props.theme.codemirror.border};
@@ -9,39 +9,9 @@ const StyledWrapper = styled.div`
     line-break: anywhere;
   }
 
-  .CodeMirror-overlayscroll-horizontal div,
-  .CodeMirror-overlayscroll-vertical div {
-    background: #d2d7db;
-  }
-
-  textarea.cm-editor {
-    position: relative;
-  }
-
-  // Todo: dark mode temporary fix
-  // Clean this
-  .CodeMirror.cm-s-monokai {
-    .CodeMirror-overlayscroll-horizontal div,
-    .CodeMirror-overlayscroll-vertical div {
-      background: #444444;
-    }
-  }
-
-  .cm-s-monokai span.cm-property,
-  .cm-s-monokai span.cm-attribute {
-    color: #9cdcfe !important;
-  }
-
-  .cm-s-monokai span.cm-string {
-    color: #ce9178 !important;
-  }
-
-  .cm-s-monokai span.cm-number {
-    color: #b5cea8 !important;
-  }
-
-  .cm-s-monokai span.cm-atom {
-    color: #569cd6 !important;
+  .bruno-cm6-editor .cm-scroller {
+    line-break: anywhere;
+    overflow: auto;
   }
 
   .cm-variable-valid {

--- a/packages/bruno-app/src/components/FileEditor/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/FileEditor/CodeEditor/index.js
@@ -1,218 +1,140 @@
 /**
- *  Copyright (c) 2021 GraphQL Contributors.
- *
- *  This source code is licensed under the MIT license found in the
- *  LICENSE file in the root directory of this source tree.
+ * File editor (env dotenv) — migrated to CodeMirror 6.
  */
 
-import React, { createRef } from 'react';
-import isEqual from 'lodash/isEqual';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { keymap } from '@codemirror/view';
 import { getEnvironmentVariables } from 'utils/collections';
-import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
+import BrunoCodeEditor, { PRESETS } from 'components/BrunoCodeEditor';
+import CodeMirrorSearch6 from 'components/CodeMirrorSearch6';
+import { brunoVariablesHighlight } from 'utils/codemirror6/extensions/brunoVariablesHighlight';
+import { createCm5Compat } from 'utils/codemirror6/compat';
 import StyledWrapper from './StyledWrapper';
-import * as jsonlint from '@prantlf/jsonlint';
-import { JSHINT } from 'jshint';
-import CodeMirrorSearch from 'components/CodeMirrorSearch';
-import { buildSearchKeyBindings } from 'components/CodeMirrorSearch/searchKeyBindings';
-let CodeMirror;
+
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
 
-if (!SERVER_RENDERED) {
-  CodeMirror = require('codemirror');
-  window.jsonlint = jsonlint;
-  window.JSHINT = JSHINT;
-}
+export default function CodeEditor({
+  value = '',
+  mode = 'application/ld+json',
+  theme,
+  readOnly = false,
+  onEdit,
+  font,
+  initialScroll = 0,
+  onScroll,
+  toggleFileMode,
+  collection
+}) {
+  const [searchBarVisible, setSearchBarVisible] = useState(false);
+  const searchBarRef = useRef(null);
+  const viewRef = useRef(null);
+  const cachedValueRef = useRef(value);
+  const searchVisibleRef = useRef(false);
+  const readOnlyRef = useRef(readOnly);
+  searchVisibleRef.current = searchBarVisible;
+  readOnlyRef.current = readOnly;
 
-export default class CodeEditor extends React.Component {
-  constructor(props) {
-    super(props);
+  const variables = getEnvironmentVariables(collection);
 
-    // Keep a cached version of the value, this cache will be updated when the
-    // editor is updated, which can later be used to protect the editor from
-    // unnecessary updates during the update lifecycle.
-    this.cachedValue = props.value || '';
-    this.variables = {};
-    this.searchBarRef = createRef();
+  const openSearch = useCallback(() => {
+    const compat = createCm5Compat(viewRef.current);
+    if (!compat) return;
+    const selected = compat.getSelection();
+    const cursor = compat.getCursor('from');
+    setSearchBarVisible(true);
+    setTimeout(() => {
+      if (selected) {
+        searchBarRef.current?.setSearch(selected, cursor);
+      } else {
+        searchBarRef.current?.focusAtCursor(cursor);
+      }
+    }, 0);
+  }, []);
 
-    this.lintOptions = {
-      esversion: 11,
-      expr: true,
-      asi: true
-    };
+  const openReplace = useCallback(() => {
+    if (readOnlyRef.current) return;
+    setSearchBarVisible(true);
+    setTimeout(() => {
+      searchBarRef.current?.focus();
+      searchBarRef.current?.openReplace();
+    }, 0);
+  }, []);
 
-    this.state = {
-      searchBarVisible: false
-    };
-  }
-
-  componentDidMount() {
-    const editor = (this.editor = CodeMirror(this._node, {
-      value: this.props.value || '',
-      lineNumbers: true,
-      lineWrapping: true,
-      tabSize: 2,
-      mode: this.props.mode || 'application/ld+json',
-      keyMap: 'sublime',
-      autoCloseBrackets: true,
-      matchBrackets: true,
-      showCursorWhenSelecting: true,
-      foldGutter: true,
-      gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter', 'CodeMirror-lint-markers'],
-      lint: this.lintOptions,
-      readOnly: this.props.readOnly,
-      scrollbarStyle: 'overlay',
-      theme: this.props.theme === 'dark' ? 'monokai' : 'default',
-      extraKeys: {
-        'Shift-Cmd-M': () => {
-          if (this.props.toggleFileMode) {
-            this.props.toggleFileMode();
+  const extraExtensions = useMemo(() => {
+    const exts = [brunoVariablesHighlight(variables, { highlightPathParams: false })];
+    exts.push(
+      keymap.of([
+        { key: 'Mod-f', run: () => {
+          openSearch(); return true;
+        } },
+        { key: 'Ctrl-h', run: () => {
+          openReplace(); return true;
+        } },
+        { key: 'Mod-Alt-f', run: () => {
+          openReplace(); return true;
+        } },
+        {
+          key: 'Escape',
+          run: () => {
+            if (searchVisibleRef.current) {
+              searchBarRef.current?.close();
+              return true;
+            }
+            return false;
           }
         },
-        'Shift-Ctrl-M': () => {
-          if (this.props.toggleFileMode) {
-            this.props.toggleFileMode();
-          }
-        },
-        ...buildSearchKeyBindings({
-          setState: (update, cb) => this.setState(update, cb),
-          searchBarRef: this.searchBarRef,
-          isSearchBarVisible: () => this.state.searchBarVisible,
-          isReadOnly: () => this.props.readOnly
-        }),
-        'Tab': function (cm) {
-          cm.getSelection().includes('\n') || editor.getLine(cm.getCursor().line) == cm.getSelection()
-            ? cm.execCommand('indentMore')
-            : cm.replaceSelection('  ', 'end');
-        },
-        'Shift-Tab': 'indentLess',
-        'Ctrl-Space': 'autocomplete',
-        'Cmd-Space': 'autocomplete',
-        'Ctrl-Y': 'foldAll',
-        'Cmd-Y': 'foldAll',
-        'Ctrl-I': 'unfoldAll',
-        'Cmd-I': 'unfoldAll'
-      }
-    }));
-    if (editor) {
-      editor.setOption('lint', this.props.mode && editor.getValue().trim().length > 0 ? this.lintOptions : false);
-      editor.on('change', this._onEdit);
-      editor.scrollTo(null, this.props.initialScroll);
-      this._lastScrollTop = this.props.initialScroll || 0;
-      editor.on('scroll', this._onScroll);
-      this.addOverlay();
-
-      const cmInput = editor.getInputField();
-      if (cmInput) {
-        cmInput.classList.add('mousetrap');
-      }
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    // Ensure the changes caused by this update are not interpreted as
-    // user-input changes which could otherwise result in an infinite
-    // event loop.
-    this.ignoreChangeEvent = true;
-    if (this.props.schema !== prevProps.schema && this.editor) {
-      this.editor.options.lint.schema = this.props.schema;
-      this.editor.options.hintOptions.schema = this.props.schema;
-      this.editor.options.info.schema = this.props.schema;
-      this.editor.options.jump.schema = this.props.schema;
-      CodeMirror.signal(this.editor, 'change', this.editor);
-    }
-    if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      const cursor = this.editor.getCursor();
-      this.cachedValue = this.props.value;
-      this.editor.setValue(this.props.value);
-      this.editor.setCursor(cursor);
-    }
-
-    if (this.editor) {
-      let variables = getEnvironmentVariables(this.props.collection);
-      if (!isEqual(variables, this.variables)) {
-        this.addOverlay();
-      }
-    }
-
-    if (this.props.theme !== prevProps.theme && this.editor) {
-      this.editor.setOption('theme', this.props.theme === 'dark' ? 'monokai' : 'default');
-    }
-
-    if (this.props.initialScroll !== prevProps.initialScroll && this.editor) {
-      this.editor.scrollTo(null, this.props.initialScroll);
-    }
-    this.ignoreChangeEvent = false;
-  }
-
-  componentWillUnmount() {
-    if (this.editor) {
-      this.editor.off('change', this._onEdit);
-      this.editor.off('scroll', this._onScroll);
-      if (typeof this.props.onScroll === 'function') {
-        this.props.onScroll(this._lastScrollTop || 0);
-      }
-      const editorElement = this.editor.getWrapperElement();
-      if (editorElement && editorElement.parentNode) {
-        editorElement.parentNode.removeChild(editorElement);
-      }
-      this.editor = null;
-      this._node = null;
-    }
-  }
-
-  render() {
-    if (this.editor) {
-      this.editor.refresh();
-    }
-    return (
-      <StyledWrapper
-        className="h-full w-full"
-        aria-label="Code Editor"
-        font={this.props.font}
-      >
-        <CodeMirrorSearch
-          ref={this.searchBarRef}
-          visible={this.state.searchBarVisible}
-          editor={this.editor}
-          readOnly={this.props.readOnly}
-          onClose={() => this.setState({ searchBarVisible: false })}
-        />
-        <div
-          ref={(node) => {
-            this._node = node;
-          }}
-          style={{ height: '100%' }}
-        />
-      </StyledWrapper>
+        ...(toggleFileMode
+          ? [{ key: 'Shift-Mod-m', run: () => {
+              toggleFileMode(); return true;
+            } }]
+          : [])
+      ])
     );
+    return exts;
+  }, [variables, openSearch, openReplace, toggleFileMode]);
+
+  const handleChange = useCallback((newValue) => {
+    cachedValueRef.current = newValue;
+    onEdit?.(newValue);
+  }, [onEdit]);
+
+  const handleViewRef = useCallback((view) => {
+    viewRef.current = view;
+    if (view && initialScroll) {
+      view.scrollDOM.scrollTop = initialScroll;
+    }
+    if (view && onScroll) {
+      view.scrollDOM.addEventListener('scroll', () => {
+        onScroll(view.scrollDOM.scrollTop);
+      });
+    }
+  }, [initialScroll, onScroll]);
+
+  if (SERVER_RENDERED) {
+    return <StyledWrapper className="h-full w-full" aria-label="Code Editor" font={font} />;
   }
 
-  addOverlay = () => {
-    const mode = this.props.mode || 'application/ld+json';
-    let variables = getEnvironmentVariables(this.props.collection);
-    this.variables = variables;
-
-    defineCodeMirrorBrunoVariablesMode(variables, mode);
-    this.editor.setOption('mode', 'brunovariables');
-  };
-
-  _onEdit = () => {
-    if (!this.ignoreChangeEvent && this.editor) {
-      this.editor.setOption('lint', this.editor.getValue().trim().length > 0 ? this.lintOptions : false);
-      this.cachedValue = this.editor.getValue();
-      if (this.props.onEdit) {
-        this.props.onEdit(this.cachedValue);
-      }
-    }
-  };
-
-  _onScroll = () => {
-    if (!this.editor) return;
-    const wrapper = this.editor.getWrapperElement();
-    if (wrapper && wrapper.offsetParent === null) return;
-    this._lastScrollTop = this.editor.getScrollInfo().top;
-    if (typeof this.props.onScroll === 'function') {
-      this.props.onScroll(this._lastScrollTop);
-    }
-  };
+  return (
+    <StyledWrapper className="h-full w-full" aria-label="Code Editor" font={font}>
+      <CodeMirrorSearch6
+        ref={searchBarRef}
+        visible={searchBarVisible}
+        view={viewRef.current}
+        readOnly={readOnly}
+        onClose={() => setSearchBarVisible(false)}
+      />
+      <BrunoCodeEditor
+        ref={handleViewRef}
+        value={value}
+        mode={mode}
+        theme={theme}
+        readOnly={readOnly}
+        onChange={handleChange}
+        preset={PRESETS.FILE}
+        font={font}
+        enableLint={Boolean(value?.trim())}
+        extraExtensions={extraExtensions}
+      />
+    </StyledWrapper>
+  );
 }

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -1,254 +1,159 @@
-import React, { Component } from 'react';
-import isEqual from 'lodash/isEqual';
-import { getAllVariables } from 'utils/collections';
-import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
-import { setupAutoComplete } from 'utils/codemirror/autocomplete';
-import { MaskedEditor } from 'utils/common/masked-editor';
-import StyledWrapper from './StyledWrapper';
-import { setupLinkAware } from 'utils/codemirror/linkAware';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTheme } from 'styled-components';
 import { IconEye, IconEyeOff } from '@tabler/icons';
+import { keymap } from '@codemirror/view';
+import { getAllVariables } from 'utils/collections';
+import { PRESETS } from 'components/BrunoCodeEditor/presets';
+import { useBrunoExtensions } from 'components/BrunoCodeEditor/useBrunoExtensions';
+import { useBrunoCodeMirror } from 'components/BrunoCodeEditor/useBrunoCodeMirror';
+import { brunoVariablesHighlight } from 'utils/codemirror6/extensions/brunoVariablesHighlight';
+import { setupAutoComplete6 } from 'utils/codemirror6/extensions/autocomplete';
+import { setupLinkAware6 } from 'utils/codemirror6/extensions/linkAware';
+import { setupBrunoVarInfo6 } from 'utils/codemirror6/extensions/brunoVarInfo';
+import { createMaskedEditor6 } from 'utils/codemirror6/extensions/maskedEditor';
+import StyledWrapper from './StyledWrapper';
 
-const CodeMirror = require('codemirror');
+const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
 
-class MultiLineEditor extends Component {
-  constructor(props) {
-    super(props);
-    // Keep a cached version of the value, this cache will be updated when the
-    // editor is updated, which can later be used to protect the editor from
-    // unnecessary updates during the update lifecycle.
-    this.cachedValue = props.value || '';
-    this.editorRef = React.createRef();
-    this.variables = {};
-    this.readOnly = props.readOnly || false;
+export default function MultiLineEditor({
+  value = '',
+  theme,
+  placeholder,
+  readOnly = false,
+  onChange,
+  collection,
+  item,
+  isSecret = false,
+  hideSecretEye = false,
+  onMaskChange,
+  autocomplete = [],
+  enableBrunoVarInfo = true,
+  className = '',
+  testId,
+  name
+}) {
+  const styledTheme = useTheme();
+  const cachedRef = useRef(value);
+  const maskedRef = useRef(null);
+  const cleanupRef = useRef({});
+  const editorViewRef = useRef(null);
+  const [maskInput, setMaskInput] = useState(isSecret);
 
-    this.state = {
-      maskInput: props.isSecret || false // Always mask the input by default (if it's a secret)
-    };
-  }
+  const variables = getAllVariables(collection, item);
 
-  componentDidMount() {
-    // Initialize CodeMirror as a single line editor
-    /** @type {import("codemirror").Editor} */
-    const variables = getAllVariables(this.props.collection, this.props.item);
-    /**
-     * No-op. We claim Cmd-Enter / Ctrl-Enter here only to suppress CodeMirror's
-     * sublime keymap default (insertLineAfter), which would otherwise insert a
-     * newline. sendRequest dispatch is owned by Mousetrap — the editor input has
-     * the `mousetrap` class (added below) so the global
-     * useKeybinding('sendRequest', …) in RequestTabPanel handles it, and only
-     * in request tabs. Falling through with CodeMirror.Pass when onRun is absent
-     * would re-introduce the newline in collection/folder-level editors.
-     */
-    const runShortcut = () => {};
+  const inlineKeys = useMemo(() => keymap.of([
+    { key: 'Mod-f', run: () => true },
+    { key: 'Tab', run: () => true },
+    { key: 'Shift-Tab', run: () => true },
+    { key: 'Mod-Enter', run: () => true }
+  ]), []);
 
-    this.editor = CodeMirror(this.editorRef.current, {
-      lineWrapping: false,
-      lineNumbers: false,
-      theme: this.props.theme === 'dark' ? 'monokai' : 'default',
-      placeholder: this.props.placeholder,
-      mode: 'brunovariables',
-      brunoVarInfo: this.props.enableBrunoVarInfo !== false ? {
-        variables,
-        collection: this.props.collection,
-        item: this.props.item
-      } : false,
-      readOnly: this.props.readOnly,
-      tabindex: 0,
-      extraKeys: {
-        'Cmd-F': () => {},
-        'Ctrl-F': () => {},
-        'Cmd-Enter': runShortcut,
-        'Ctrl-Enter': runShortcut,
-        // Tabbing disabled to make tabindex work
-        'Tab': false,
-        'Shift-Tab': false
-      }
-    });
+  const extraExtensions = useMemo(() => [
+    brunoVariablesHighlight(variables, { highlightPathParams: false }),
+    inlineKeys
+  ], [variables, inlineKeys]);
 
-    const getAllVariablesHandler = () => getAllVariables(this.props.collection, this.props.item);
-    const getAnywordAutocompleteHints = () => this.props.autocomplete || [];
+  const extensions = useBrunoExtensions({
+    preset: PRESETS.INLINE_MULTI,
+    mode: 'text/plain',
+    theme,
+    styledTheme,
+    readOnly,
+    enableLint: false,
+    extraExtensions
+  });
 
-    // Setup AutoComplete Helper
-    const autoCompleteOptions = {
-      showHintsFor: ['variables'],
-      getAllVariables: getAllVariablesHandler,
-      getAnywordAutocompleteHints
-    };
+  const handleChange = useCallback((newValue) => {
+    cachedRef.current = newValue;
+    onChange?.(newValue);
+    requestAnimationFrame(() => editorViewRef.current?.requestMeasure());
+  }, [onChange]);
 
-    this.brunoAutoCompleteCleanup = setupAutoComplete(
-      this.editor,
-      autoCompleteOptions
-    );
-
-    setupLinkAware(this.editor);
-
-    // Add mousetrap calss so Mousetrap captures shortcuts even when Codemirror is focused
-    const cmInput = this.editor.getInputField();
-    if (cmInput) {
-      cmInput.classList.add('mousetrap');
-    }
-
-    this.editor.setValue(String(this.props.value) || '');
-    this.editor.on('change', this._onEdit);
-    this.editor.on('blur', this._onBlur);
-    this.addOverlay(variables);
-
-    // Initialize masking if this is a secret field
-    this.setState({ maskInput: this.props.isSecret }, () => {
-      this.props.onMaskChange?.(this.state.maskInput);
-    });
-    this._enableMaskedEditor(this.props.isSecret);
-  }
-
-  _onBlur = () => {
-    if (this.editor) {
-      this.editor.setCursor(this.editor.getCursor());
-    }
-  };
-
-  _onEdit = () => {
-    if (!this.ignoreChangeEvent && this.editor) {
-      this.cachedValue = this.editor.getValue();
-      if (this.props.onChange) {
-        this.props.onChange(this.cachedValue);
-      }
-      requestAnimationFrame(() => this.editor?.refresh());
-    }
-  };
-
-  /** Enable or disable masking the rendered content of the editor */
-  _enableMaskedEditor = (enabled) => {
-    if (typeof enabled !== 'boolean') return;
-
-    if (enabled == true) {
-      if (!this.maskedEditor) this.maskedEditor = new MaskedEditor(this.editor, '*');
-      this.maskedEditor.enable();
-    } else {
-      if (this.maskedEditor) {
-        this.maskedEditor.disable();
-        this.maskedEditor.destroy();
-        this.maskedEditor = null;
-      }
-    }
-  };
-
-  componentDidUpdate(prevProps) {
-    // Ensure the changes caused by this update are not interpreted as
-    // user-input changes which could otherwise result in an infinite
-    // event loop.
-    this.ignoreChangeEvent = true;
-
-    let variables = getAllVariables(this.props.collection, this.props.item);
-    if (!isEqual(variables, this.variables)) {
-      if (this.props.enableBrunoVarInfo !== false && this.editor.options.brunoVarInfo) {
-        this.editor.options.brunoVarInfo.variables = variables;
-      }
-      this.addOverlay(variables);
-    }
-
-    // Update collection and item when they change
-    if (this.props.enableBrunoVarInfo !== false && this.editor.options.brunoVarInfo) {
-      if (!isEqual(this.props.collection, this.editor.options.brunoVarInfo.collection)) {
-        this.editor.options.brunoVarInfo.collection = this.props.collection;
-      }
-      if (!isEqual(this.props.item, this.editor.options.brunoVarInfo.item)) {
-        this.editor.options.brunoVarInfo.item = this.props.item;
-      }
-    }
-    if (this.props.theme !== prevProps.theme && this.editor) {
-      this.editor.setOption('theme', this.props.theme === 'dark' ? 'monokai' : 'default');
-    }
-    if (this.props.readOnly !== prevProps.readOnly && this.editor) {
-      this.editor.setOption('readOnly', this.props.readOnly);
-    }
-    if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      const cursor = this.editor.getCursor();
-      this.cachedValue = String(this.props.value);
-      this.editor.setValue(String(this.props.value) || '');
-      this.editor.setCursor(cursor);
-      // Re-apply masking after setValue() since it destroys all CodeMirror marks
-      if (this.maskedEditor && this.maskedEditor.isEnabled()) {
-        this.maskedEditor.update();
-      }
-      requestAnimationFrame(() => this.editor?.refresh());
-    }
-    if (!isEqual(this.props.isSecret, prevProps.isSecret)) {
-      // If the secret flag has changed, update the editor to reflect the change
-      this._enableMaskedEditor(this.props.isSecret);
-      // also set the maskInput flag to the new value
-      this.setState({ maskInput: this.props.isSecret }, () => {
-        this.props.onMaskChange?.(this.state.maskInput);
+  const { setContainer } = useBrunoCodeMirror({
+    value,
+    extensions,
+    onChange: handleChange,
+    onCreateEditor: (view) => {
+      editorViewRef.current = view;
+      cleanupRef.current.autocomplete = setupAutoComplete6(view, {
+        showHintsFor: ['variables'],
+        getAllVariables: () => getAllVariables(collection, item),
+        getAnywordAutocompleteHints: () => autocomplete || []
       });
-    }
-    if (this.props.readOnly !== prevProps.readOnly && this.editor) {
-      this.editor.setOption('readOnly', this.props.readOnly || false);
-    }
-    if (this.props.placeholder !== prevProps.placeholder && this.editor) {
-      this.editor.setOption('placeholder', this.props.placeholder);
-    }
-    this.ignoreChangeEvent = false;
-  }
+      cleanupRef.current.linkAware = setupLinkAware6(view);
+      if (enableBrunoVarInfo) {
+        cleanupRef.current.varInfo = setupBrunoVarInfo6(view, {
+          variables,
+          collection,
+          item
+        });
+      }
+      if (isSecret) {
+        maskedRef.current = createMaskedEditor6(view);
+        maskedRef.current.enable();
+      }
+    },
+    readOnly
+  });
 
-  componentWillUnmount() {
-    if (this.brunoAutoCompleteCleanup) {
-      this.brunoAutoCompleteCleanup();
+  useEffect(() => {
+    if (isSecret) {
+      if (!maskedRef.current && editorViewRef.current) {
+        maskedRef.current = createMaskedEditor6(editorViewRef.current);
+      }
+      maskedRef.current?.enable();
+      setMaskInput(true);
+      onMaskChange?.(true);
+    } else {
+      maskedRef.current?.disable();
+      maskedRef.current?.destroy();
+      maskedRef.current = null;
+      setMaskInput(false);
+      onMaskChange?.(false);
     }
-    if (this.editor?._destroyLinkAware) {
-      this.editor._destroyLinkAware();
-    }
-    if (this.maskedEditor) {
-      this.maskedEditor.destroy();
-      this.maskedEditor = null;
-    }
-    if (this.editor) {
-      this.editor.off('change', this._onEdit);
-      this.editor.off('blur', this._onBlur);
-      this.editor.getWrapperElement().remove();
-    }
-  }
+  }, [isSecret, onMaskChange]);
 
-  addOverlay = (variables) => {
-    this.variables = variables;
-    defineCodeMirrorBrunoVariablesMode(variables, 'text/plain', false, true);
-    this.editor.setOption('mode', 'brunovariables');
+  useEffect(() => {
+    return () => {
+      cleanupRef.current.autocomplete?.();
+      cleanupRef.current.linkAware?.();
+      cleanupRef.current.varInfo?.();
+      maskedRef.current?.destroy();
+    };
+  }, []);
+
+  const toggleVisibleSecret = () => {
+    const next = !maskInput;
+    setMaskInput(next);
+    if (next) {
+      if (!maskedRef.current && editorViewRef.current) {
+        maskedRef.current = createMaskedEditor6(editorViewRef.current);
+      }
+      maskedRef.current?.enable();
+    } else {
+      maskedRef.current?.disable();
+    }
+    onMaskChange?.(next);
   };
 
-  /**
-   * @brief Toggle the visibility of the secret value
-   */
-  toggleVisibleSecret = () => {
-    const maskInput = !this.state.maskInput;
-    this.setState({ maskInput }, () => {
-      this._enableMaskedEditor(maskInput);
-      this.props.onMaskChange?.(maskInput);
-    });
-  };
-
-  /**
-   * @brief Eye icon to show/hide the secret value
-   * @returns ReactComponent The eye icon
-   */
-  secretEye = (isSecret) => {
-    return isSecret === true ? (
-      <button className="mx-2" data-testid="secret-reveal-toggle" onClick={() => this.toggleVisibleSecret()}>
-        {this.state.maskInput === true ? (
-          <IconEyeOff size={18} strokeWidth={2} />
-        ) : (
-          <IconEye size={18} strokeWidth={2} />
-        )}
-      </button>
-    ) : null;
-  };
-
-  render() {
-    const wrapperClass = `multi-line-editor grow ${this.props.readOnly ? 'read-only' : ''}`;
-    const testId = this.props.testId ?? (this.props.name ? `test-multiline-editor-${this.props.name}` : undefined);
-    return (
-      <div data-testid={testId} className={`flex flex-row justify-between w-full overflow-x-auto ${this.props.className}`}>
-        <StyledWrapper ref={this.editorRef} className={wrapperClass} />
-        {!this.props.hideSecretEye && this.secretEye(this.props.isSecret)}
-      </div>
-    );
+  if (SERVER_RENDERED) {
+    return <div className={`flex flex-row justify-between w-full overflow-x-auto ${className}`} />;
   }
+
+  const wrapperTestId = testId ?? (name ? `test-multiline-editor-${name}` : undefined);
+
+  return (
+    <div data-testid={wrapperTestId} className={`flex flex-row justify-between w-full overflow-x-auto ${className}`}>
+      <StyledWrapper
+        ref={setContainer}
+        className={`multi-line-editor grow bruno-cm6-editor ${readOnly ? 'read-only' : ''}`}
+        placeholder={placeholder}
+      />
+      {!hideSecretEye && isSecret && (
+        <button type="button" className="mx-2" data-testid="secret-reveal-toggle" onClick={toggleVisibleSecret}>
+          {maskInput ? <IconEyeOff size={18} strokeWidth={2} /> : <IconEye size={18} strokeWidth={2} />}
+        </button>
+      )}
+    </div>
+  );
 }
-export default MultiLineEditor;


### PR DESCRIPTION
## Summary
- Migrate `MultiLineEditor` from class-based CM5 to `useBrunoCodeMirror`

## Test plan
- [ ] Edit multiline fields (headers, notes, body fields)
- [ ] Verify autocomplete and link-aware URLs