### PR TITLE
feat(cm6): PR6 — Main CodeEditor

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -1,514 +1,333 @@
 /**
- *  Copyright (c) 2021 GraphQL Contributors.
- *
- *  This source code is licensed under the MIT license found in the
- *  LICENSE file in the root directory of this source tree.
+ * Main Bruno code editor — migrated to CodeMirror 6.
  */
 
-import 'utils/codemirror/setup';
-import React, { createRef } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { debounce, isEqual } from 'lodash';
-import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
-import { setupAutoComplete, showRootHints } from 'utils/codemirror/autocomplete';
-import { setupAiAutocomplete } from 'utils/codemirror/aiGhostText';
-import { buildAutocompleteContext } from 'utils/ai';
-import StyledWrapper from './StyledWrapper';
-import * as jsonlint from '@prantlf/jsonlint';
-import { JSHINT } from 'jshint';
-import stripJsonComments from 'strip-json-comments';
+import { debounce } from 'lodash';
+import { keymap } from '@codemirror/view';
+import { indentLess, indentMore } from '@codemirror/commands';
 import { getAllVariables } from 'utils/collections';
-import { setupLinkAware } from 'utils/codemirror/linkAware';
-import { setupLintErrorTooltip } from 'utils/codemirror/lint-errors';
-import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
-import CodeMirrorSearch from 'components/CodeMirrorSearch/index';
-import { buildSearchKeyBindings } from 'components/CodeMirrorSearch/searchKeyBindings';
+import { buildAutocompleteContext } from 'utils/ai';
+import BrunoCodeEditor, { PRESETS } from 'components/BrunoCodeEditor';
+import CodeMirrorSearch6 from 'components/CodeMirrorSearch6';
+import { createCm5Compat } from 'utils/codemirror6/compat';
+import { brunoVariablesHighlight } from 'utils/codemirror6/extensions/brunoVariablesHighlight';
+import { setupAutoComplete6, showRootHints } from 'utils/codemirror6/extensions/autocomplete';
+import { setupAiAutocomplete6 } from 'utils/codemirror6/extensions/aiGhostText';
+import { setupBrunoVarInfo6 } from 'utils/codemirror6/extensions/brunoVarInfo';
+import { setupLinkAware6 } from 'utils/codemirror6/extensions/linkAware';
+import { setupLintErrorTooltip6 } from 'utils/codemirror6/extensions/lintTooltips';
+import { setupCodeMirrorResizeRefresh } from 'utils/codemirror6/extensions/resizeRefresh';
+import { captureEditorState6, applyEditorState6 } from 'utils/codemirror6/extensions/editorPersistence';
 import {
-  applyEditorState,
-  captureEditorState,
   getDocKey,
   readPersistedEditorState,
   writePersistedEditorState
 } from './state-persistence';
 import { usePersistenceScope } from 'hooks/usePersistedState/PersistedScopeProvider';
+import StyledWrapper from './StyledWrapper';
 
-const CodeMirror = require('codemirror');
-window.jsonlint = jsonlint;
-window.JSHINT = JSHINT;
+const CodeEditor = forwardRef(function CodeEditor(
+  {
+    value = '',
+    mode = 'application/ld+json',
+    theme,
+    readOnly = false,
+    onEdit,
+    onScroll,
+    initialScroll = 0,
+    containScroll = false,
+    collection,
+    item,
+    font,
+    fontSize,
+    enableBrunoVarInfo = true,
+    enableVariableHighlighting = true,
+    showHintsFor,
+    scriptType,
+    aiPreferences,
+    persistenceScope,
+    docKey: docKeyProp,
+    testId,
+    onSearchBarVisibilityChange
+  },
+  ref
+) {
+  const [searchBarVisible, setSearchBarVisible] = useState(false);
+  const searchBarRef = useRef(null);
+  const viewRef = useRef(null);
+  const compatRef = useRef(null);
+  const cachedRef = useRef(value);
+  const currentDocKeyRef = useRef(null);
+  const cleanupRef = useRef({});
+  const searchVisibleRef = useRef(false);
+  const readOnlyRef = useRef(readOnly);
+  const lastScrollRef = useRef(initialScroll || 0);
+  searchVisibleRef.current = searchBarVisible;
+  readOnlyRef.current = readOnly;
 
-const TAB_SIZE = 2;
+  const variables = getAllVariables(collection, item);
 
-class CodeEditor extends React.Component {
-  constructor(props) {
-    super(props);
+  const openSearch = useCallback(() => {
+    const compat = compatRef.current;
+    if (!compat) return;
+    const selected = compat.getSelection();
+    const cursor = compat.getCursor('from');
+    setSearchBarVisible(true);
+    setTimeout(() => {
+      if (selected) {
+        searchBarRef.current?.setSearch(selected, cursor);
+      } else {
+        searchBarRef.current?.focusAtCursor(cursor);
+      }
+    }, 0);
+  }, []);
 
-    // Keep a cached version of the value, this cache will be updated when the
-    // editor is updated, which can later be used to protect the editor from
-    // unnecessary updates during the update lifecycle.
-    this.cachedValue = props.value || '';
-    this.variables = {};
-    this.searchResultsCountElementId = 'search-results-count';
-    this.searchBarRef = createRef();
+  const openReplace = useCallback(() => {
+    if (readOnlyRef.current) return;
+    setSearchBarVisible(true);
+    setTimeout(() => {
+      searchBarRef.current?.focus();
+      searchBarRef.current?.openReplace();
+    }, 0);
+  }, []);
 
-    this.lintOptions = {
-      esversion: 11,
-      expr: true,
-      asi: true,
-      highlightLines: true
-    };
-
-    this.state = {
-      searchBarVisible: false
-    };
-  }
-
-  // Thin wrapper around the pure getDocKey helper from state-persistence.js.
-  // Kept on the class so the rest of the lifecycle code reads naturally.
-  _getDocKey() {
-    return getDocKey(this.props);
-  }
-
-  componentDidMount() {
-    const variables = getAllVariables(this.props.collection, this.props.item);
-    /**
-     * No-op. We claim Cmd-Enter / Ctrl-Enter here only to suppress CodeMirror's
-     * sublime keymap default (insertLineAfter), which would otherwise insert a
-     * newline. sendRequest dispatch is owned by Mousetrap — the editor input has
-     * the `mousetrap` class (added below) so the global
-     * useKeybinding('sendRequest', …) in RequestTabPanel handles it, and only
-     * in request tabs. Falling through with CodeMirror.Pass when onRun is absent
-     * would re-introduce the newline in collection/folder-level editors.
-     */
-    const runShortcut = () => {};
-
-    const editor = (this.editor = CodeMirror(this._node, {
-      value: this.props.value || '',
-      placeholder: '...',
-      lineNumbers: true,
-      lineWrapping: this.props.enableLineWrapping ?? true,
-      tabSize: TAB_SIZE,
-      mode: this.props.mode || 'application/ld+json',
-      brunoVarInfo: this.props.enableBrunoVarInfo !== false ? {
-        variables,
-        collection: this.props.collection,
-        item: this.props.item
-      } : false,
-      keyMap: 'sublime',
-      autoCloseBrackets: true,
-      matchBrackets: true,
-      showCursorWhenSelecting: true,
-      foldGutter: true,
-      gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-      lint: this.lintOptions,
-      readOnly: this.props.readOnly,
-      scrollbarStyle: 'overlay',
-      theme: this.props.theme === 'dark' ? 'monokai' : 'default',
-      extraKeys: {
-        ...buildSearchKeyBindings({
-          setState: (update, cb) => this.setState(update, cb),
-          searchBarRef: this.searchBarRef,
-          isSearchBarVisible: () => this.state.searchBarVisible,
-          isReadOnly: () => this.props.readOnly
-        }),
-        'Cmd-Enter': runShortcut,
-        'Ctrl-Enter': runShortcut,
-        'Tab': function (cm) {
-          cm.getSelection().includes('\n') || editor.getLine(cm.getCursor().line) == cm.getSelection()
-            ? cm.execCommand('indentMore')
-            : cm.replaceSelection('  ', 'end');
-        },
-        'Shift-Tab': 'indentLess',
-        'Ctrl-Space': (cm) => {
-          showRootHints(cm, this.props.showHintsFor);
-        },
-        'Cmd-Space': (cm) => {
-          showRootHints(cm, this.props.showHintsFor);
-        },
-        'Ctrl-Y': 'foldAll',
-        'Cmd-Y': 'foldAll',
-        'Ctrl-I': 'unfoldAll',
-        'Cmd-I': 'unfoldAll',
-        'Ctrl-/': () => {
-          if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
-            this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
-          } else {
-            this.editor.toggleComment();
+  const extraExtensions = useMemo(() => {
+    const exts = [];
+    if (enableVariableHighlighting) {
+      exts.push(brunoVariablesHighlight(variables, { highlightPathParams: false }));
+    }
+    exts.push(
+      keymap.of([
+        { key: 'Mod-f', run: () => {
+          openSearch(); return true;
+        } },
+        { key: 'Ctrl-h', run: () => {
+          openReplace(); return true;
+        } },
+        { key: 'Mod-Alt-f', run: () => {
+          openReplace(); return true;
+        } },
+        {
+          key: 'Escape',
+          run: () => {
+            if (searchVisibleRef.current) {
+              searchBarRef.current?.close();
+              return true;
+            }
+            return false;
           }
         },
-        'Cmd-/': () => {
-          if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
-            this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
-          } else {
-            this.editor.toggleComment();
+        { key: 'Mod-Enter', run: () => true },
+        {
+          key: 'Tab',
+          run: (view) => {
+            const compat = createCm5Compat(view);
+            const sel = compat.getSelection();
+            if (sel.includes('\n') || compat.getLine(compat.getCursor().line) === sel) {
+              return indentMore(view);
+            }
+            compat.replaceSelection('  ');
+            return true;
+          }
+        },
+        { key: 'Shift-Tab', run: (view) => indentLess(view) },
+        {
+          key: 'Mod-Space',
+          run: (view) => {
+            showRootHints(createCm5Compat(view), showHintsFor);
+            return true;
+          }
+        },
+        {
+          key: 'Ctrl-Space',
+          run: (view) => {
+            showRootHints(createCm5Compat(view), showHintsFor);
+            return true;
           }
         }
-      },
-      foldOptions: {
-        widget: (from, to) => {
-          let count = undefined;
-          const internal = this.editor.getRange(from, to);
-          if (this.props.mode == 'application/ld+json') {
-            if (this.editor.getLine(from.line).endsWith('[')) {
-              var toParse = '[' + internal + ']';
-            } else var toParse = '{' + internal + '}';
-            try {
-              count = Object.keys(JSON.parse(toParse)).length;
-            } catch (e) {}
-          } else if (this.props.mode == 'application/xml') {
-            const doc = new DOMParser();
-            try {
-              // add header element and remove prefix namespaces for DOMParser
-              const dcm = doc.parseFromString(
-                '<a> ' + internal.replace(/(?<=\<|<\/)\w+:/g, '') + '</a>',
-                'application/xml'
-              );
-              count = dcm.documentElement.children.length;
-            } catch (e) {}
-          }
-          return count ? `\u21A4${count}\u21A6` : '\u2194';
-        }
-      }
-    }));
-    CodeMirror.registerHelper('lint', 'json', function (text) {
-      const found = [];
-      if (!window.jsonlint) {
-        if (window.console) {
-          window.console.error('Error: window.jsonlint not defined, CodeMirror JSON linting cannot run.');
-        }
-        return found;
-      }
-      const jsonlint = window.jsonlint.parser || window.jsonlint;
-      try {
-        jsonlint.parse(stripJsonComments(text.replace(/(?<!"[^":{]*){{[^}]*}}(?![^"},]*")/g, '1')));
-      } catch (error) {
-        const { message, location } = error;
-        const line = location?.start?.line;
-        const column = location?.start?.column;
-        if (line && column) {
-          found.push({
-            from: CodeMirror.Pos(line - 1, column),
-            to: CodeMirror.Pos(line - 1, column),
-            message
-          });
-        }
-      }
-      return found;
-    });
-
-    if (editor) {
-      // CM5 was constructed with props.value, so the editor already shows the
-      // right content. Read this tab's previously persisted view state from
-      // localStorage and apply it on top — restores folds, cursor, selection,
-      // undo history, and scroll position.
-      const docKey = getDocKey(this.props);
-      this._currentDocKey = docKey;
-      this.cachedValue = editor.getValue();
-      applyEditorState(
-        editor,
-        readPersistedEditorState({ scope: this.props.persistenceScope, key: docKey }),
-        this.cachedValue
-      );
-
-      editor.setOption('lint', this.props.mode && editor.getValue().trim().length > 0 ? this.lintOptions : false);
-      editor.on('change', this._onEdit);
-
-      // Persist view state immediately when the user folds or unfolds — without
-      // this, a fold only gets saved on the next tab switch / unmount. That
-      // makes the persistence feel "delayed" or random, especially across
-      // sub-tab switches that don't change the docKey or unmount the editor.
-      // Debounced so rapid fold/unfold (e.g. Cmd-Y to fold all) doesn't write
-      // to localStorage on every event.
-      this._persistViewStateDebounced = debounce(() => {
-        if (!this.editor || !this._currentDocKey) return;
-        writePersistedEditorState({
-          scope: this.props.persistenceScope,
-          key: this._currentDocKey,
-          state: captureEditorState(this.editor)
-        });
-      }, 250);
-      editor.on('fold', this._persistViewStateDebounced);
-      editor.on('unfold', this._persistViewStateDebounced);
-
-      editor.scrollTo(null, this.props.initialScroll);
-      this._lastScrollTop = this.props.initialScroll || 0;
-      editor.on('scroll', () => {
-        const wrapper = editor.getWrapperElement();
-        if (wrapper && wrapper.offsetParent === null) return;
-        this._lastScrollTop = editor.getScrollInfo().top;
-        if (this.props.onScroll && typeof this.props.onScroll === 'function') {
-          this.props.onScroll(this._lastScrollTop);
-        }
-      });
-
-      // For editors inside a scroll container (e.g. the WebSocket message list),
-      // stop the browser from scrolling that container on focus. Otherwise a
-      // click shifts the content mid-click, landing the cursor on the wrong line
-      // and jumping the editor. preventScroll keeps CodeMirror's own scrolling.
-      if (this.props.containScroll) {
-        const inputField = editor.getInputField();
-        if (inputField && typeof inputField.focus === 'function') {
-          const nativeFocus = inputField.focus.bind(inputField);
-          inputField.focus = (options) => nativeFocus({ ...(options || {}), preventScroll: true });
-        }
-      }
-
-      this.addOverlay();
-
-      const getAllVariablesHandler = () => getAllVariables(this.props.collection, this.props.item);
-
-      // Setup AutoComplete Helper for all modes
-      const autoCompleteOptions = {
-        showHintsFor: this.props.showHintsFor,
-        getAllVariables: getAllVariablesHandler
-      };
-
-      this.brunoAutoCompleteCleanup = setupAutoComplete(
-        editor,
-        autoCompleteOptions
-      );
-
-      // AI ghost-text autocomplete (script editors only). Stays inert until
-      // the user has both enabled AI and configured a provider.
-      if (this.props.scriptType) {
-        this.aiAutocompleteCleanup = setupAiAutocomplete(editor, {
-          scriptType: this.props.scriptType,
-          isEnabled: () => {
-            const ai = this.props.aiPreferences;
-            return Boolean(ai?.enabled) && ai?.autocomplete?.enabled !== false;
-          },
-          getTriggerMode: () => this.props.aiPreferences?.autocomplete?.triggerMode || 'debounced',
-          getContext: () => buildAutocompleteContext({
-            item: this.props.item,
-            collection: this.props.collection,
-            scriptType: this.props.scriptType
-          })
-        });
-      }
-
-      setupLinkAware(editor);
-
-      // Setup lint error tooltip on line number hover
-      this.cleanupLintErrorTooltip = setupLintErrorTooltip(editor);
-
-      // Add mousetrap class so Mousetrap captures shortcuts even when CodeMirror is focused
-      const cmInput = editor.getInputField();
-      if (cmInput) {
-        cmInput.classList.add('mousetrap');
-      }
-
-      this.cleanupResizeRefresh = setupCodeMirrorResizeRefresh(editor, this._node);
-    }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    // Notify parent when the search bar opens or closes (e.g. so a fixed-height
-    // container like a WS message accordion can reserve enough room for the bar).
-    if (prevState.searchBarVisible !== this.state.searchBarVisible) {
-      this.props.onSearchBarVisibilityChange?.(this.state.searchBarVisible);
-    }
-
-    // Ensure the changes caused by this update are not interpreted as
-    // user-input changes which could otherwise result in an infinite
-    // event loop.
-    this.ignoreChangeEvent = true;
-    if (this.props.schema !== prevProps.schema && this.editor) {
-      this.editor.options.lint.schema = this.props.schema;
-      this.editor.options.hintOptions.schema = this.props.schema;
-      this.editor.options.info.schema = this.props.schema;
-      this.editor.options.jump.schema = this.props.schema;
-      CodeMirror.signal(this.editor, 'change', this.editor);
-    }
-    if (this.editor) {
-      // Two distinct update paths:
-      //   1. Doc key changed → tab switch → snapshot outgoing state, load new content, restore incoming state
-      //   2. Same doc, value changed → external content update → setValue (view state resets)
-      const newDocKey = getDocKey(this.props);
-      const docKeyChanged = newDocKey !== this._currentDocKey;
-
-      if (docKeyChanged) {
-        // Path 1 — tab switch.
-        // Snapshot the outgoing tab's view state to localStorage so a future
-        // visit can restore it. Then setValue the incoming content and apply
-        // any view state previously persisted for the incoming tab.
-        if (this._currentDocKey) {
-          writePersistedEditorState({
-            scope: this.props.persistenceScope,
-            key: this._currentDocKey,
-            state: captureEditorState(this.editor)
-          });
-        }
-        this.cachedValue = String(this?.props?.value ?? '');
-        this.editor.setValue(String(this.props.value) || '');
-        this._currentDocKey = newDocKey;
-        applyEditorState(
-          this.editor,
-          readPersistedEditorState({ scope: this.props.persistenceScope, key: newDocKey }),
-          this.cachedValue
-        );
-        // setValue resets the editor's mode-overlay state — re-apply the
-        // brunovariables overlay and re-evaluate lint config for the new content.
-        this.addOverlay();
-        this.editor.setOption(
-          'lint',
-          this.props.mode && this.editor.getValue().trim().length > 0 ? this.lintOptions : false
-        );
-      } else if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue) {
-        // Path 2 — same tab, new external value (e.g. a fresh response arrived
-        // while this tab was active). Update content; view state resets because
-        // line positions no longer correspond to anything. Invalidate the
-        // persisted snapshot too, since the saved cursor/folds/history reflect
-        // the prior content.
-        const cursor = this.editor.getCursor();
-        this.cachedValue = String(this?.props?.value ?? '');
-        this.editor.setValue(String(this.props.value) || '');
-        this.editor.setCursor(cursor);
-        writePersistedEditorState({ scope: this.props.persistenceScope, key: this._currentDocKey, state: null });
-      }
-    }
-
-    if (this.editor) {
-      const variables = getAllVariables(this.props.collection, this.props.item);
-      if (!isEqual(variables, this.variables)) {
-        this.addOverlay();
-      }
-
-      // Update collection and item when they change
-      if (this.props.enableBrunoVarInfo !== false && this.editor.options.brunoVarInfo) {
-        if (!isEqual(this.props.collection, this.editor.options.brunoVarInfo.collection)) {
-          this.editor.options.brunoVarInfo.collection = this.props.collection;
-        }
-        if (!isEqual(this.props.item, this.editor.options.brunoVarInfo.item)) {
-          this.editor.options.brunoVarInfo.item = this.props.item;
-        }
-      }
-    }
-
-    if (this.props.theme !== prevProps.theme && this.editor) {
-      this.editor.setOption('theme', this.props.theme === 'dark' ? 'monokai' : 'default');
-    }
-
-    if (this.props.initialScroll !== prevProps.initialScroll) {
-      this.editor.scrollTo(null, this.props.initialScroll);
-    }
-
-    if (this.props.enableLineWrapping !== prevProps.enableLineWrapping) {
-      this.editor.setOption('lineWrapping', this.props.enableLineWrapping);
-    }
-
-    if (this.props.mode !== prevProps.mode) {
-      this.editor.setOption('mode', this.props.mode);
-    }
-
-    if (this.props.readOnly !== prevProps.readOnly && this.editor) {
-      this.editor.setOption('readOnly', this.props.readOnly);
-    }
-
-    this.ignoreChangeEvent = false;
-  }
-
-  componentWillUnmount() {
-    if (this.editor) {
-      if (this.props.onScroll) {
-        this.props.onScroll(this._lastScrollTop);
-      }
-
-      // Snapshot view state to localStorage before tearing down the editor so
-      // the next mount of a CodeEditor with this docKey can restore folds,
-      // cursor, selection, undo history, and scroll position.
-      if (this._currentDocKey) {
-        writePersistedEditorState({
-          scope: this.props.persistenceScope,
-          key: this._currentDocKey,
-          state: captureEditorState(this.editor)
-        });
-      }
-
-      this.aiAutocompleteCleanup?.();
-      this.editor?._destroyLinkAware?.();
-      this.editor.off('change', this._onEdit);
-
-      // Tear down the debounced fold-persistence listener. Cancel any pending
-      // call so it can't fire after we've already snapshotted state above.
-      if (this._persistViewStateDebounced) {
-        this.editor.off('fold', this._persistViewStateDebounced);
-        this.editor.off('unfold', this._persistViewStateDebounced);
-        this._persistViewStateDebounced.cancel?.();
-      }
-
-      // Clean up lint error tooltip
-      this.cleanupLintErrorTooltip?.();
-      this.cleanupResizeRefresh?.();
-
-      const wrapper = this.editor.getWrapperElement();
-      wrapper?.parentNode?.removeChild(wrapper);
-
-      this.editor = null;
-    }
-
-    // Notify the parent that the search bar is gone so it can reset any
-    // height reservation it made (e.g. SingleWSMessage accordion body).
-    if (this.state.searchBarVisible) {
-      this.props.onSearchBarVisibilityChange?.(false);
-    }
-  }
-
-  render() {
-    if (this.editor) {
-      this.editor.refresh();
-    }
-    return (
-      <StyledWrapper
-        className={`h-full w-full flex flex-col relative graphiql-container ${this.props.readOnly ? 'read-only' : ''} ${this.state.searchBarVisible ? 'search-bar-visible' : ''}`}
-        aria-label="Code Editor"
-        data-testid={this.props.testId}
-        font={this.props.font}
-        fontSize={this.props.fontSize}
-      >
-        <CodeMirrorSearch
-          ref={(node) => {
-            if (!node) return;
-            this.searchBarRef.current = node;
-          }}
-          visible={this.state.searchBarVisible}
-          editor={this.editor}
-          readOnly={this.props.readOnly}
-          onClose={() => this.setState({ searchBarVisible: false })}
-        />
-        <div
-          className="editor-container"
-          ref={(node) => { this._node = node; }}
-          style={{ height: '100%', width: '100%' }}
-        />
-      </StyledWrapper>
+      ])
     );
-  }
+    return exts;
+  }, [variables, enableVariableHighlighting, showHintsFor, openSearch, openReplace]);
 
-  addOverlay = () => {
-    const mode = this.props.mode || 'application/ld+json';
-    const variables = getAllVariables(this.props.collection, this.props.item);
-    this.variables = variables;
+  useImperativeHandle(ref, () => ({
+    editor: compatRef.current
+  }), []);
 
-    // Update brunoVarInfo with latest variables
-    if (this.props.enableBrunoVarInfo !== false && this.editor.options.brunoVarInfo) {
-      this.editor.options.brunoVarInfo.variables = variables;
+  const handleViewRef = useCallback((view) => {
+    viewRef.current = view;
+    if (!view) return;
+
+    compatRef.current = createCm5Compat(view);
+
+    const docKey = docKeyProp || getDocKey({ docKey: docKeyProp, item, collection, mode, readOnly });
+    currentDocKeyRef.current = docKey;
+    cachedRef.current = view.state.doc.toString();
+
+    applyEditorState6(view, readPersistedEditorState({ scope: persistenceScope, key: docKey }), cachedRef.current);
+
+    cleanupRef.current.autocomplete = setupAutoComplete6(view, {
+      showHintsFor,
+      getAllVariables: () => getAllVariables(collection, item)
+    });
+    cleanupRef.current.linkAware = setupLinkAware6(view);
+    cleanupRef.current.lintTooltip = setupLintErrorTooltip6(view);
+    cleanupRef.current.resize = setupCodeMirrorResizeRefresh(view, view.dom.parentElement);
+
+    if (enableBrunoVarInfo) {
+      cleanupRef.current.varInfo = setupBrunoVarInfo6(view, {
+        variables,
+        collection,
+        item
+      });
     }
 
-    defineCodeMirrorBrunoVariablesMode(variables, mode, false, this.props.enableVariableHighlighting);
-    this.editor.setOption('mode', 'brunovariables');
-  };
+    if (scriptType && aiPreferences) {
+      cleanupRef.current.ai = setupAiAutocomplete6(view, {
+        scriptType,
+        isEnabled: () => Boolean(aiPreferences?.enabled) && aiPreferences?.autocomplete?.enabled !== false,
+        getTriggerMode: () => aiPreferences?.autocomplete?.triggerMode || 'debounced',
+        getContext: () => buildAutocompleteContext({ item, collection, scriptType })
+      });
+    }
 
-  _onEdit = () => {
-    if (!this.ignoreChangeEvent && this.editor) {
-      this.editor.setOption('lint', this.editor.getValue().trim().length > 0 ? this.lintOptions : false);
-      this.cachedValue = this.editor.getValue();
-      if (this.props.onEdit) {
-        this.props.onEdit(this.cachedValue);
+    if (initialScroll) {
+      view.scrollDOM.scrollTop = initialScroll;
+    }
+
+    if (onScroll) {
+      view.scrollDOM.addEventListener('scroll', () => {
+        lastScrollRef.current = view.scrollDOM.scrollTop;
+        onScroll(view.scrollDOM.scrollTop);
+      });
+    }
+
+    if (containScroll) {
+      const input = view.contentDOM;
+      const nativeFocus = input.focus.bind(input);
+      input.focus = (options) => nativeFocus({ ...(options || {}), preventScroll: true });
+    }
+
+    const persistDebounced = debounce(() => {
+      if (!currentDocKeyRef.current || !viewRef.current) return;
+      writePersistedEditorState({
+        scope: persistenceScope,
+        key: currentDocKeyRef.current,
+        state: captureEditorState6(viewRef.current)
+      });
+    }, 250);
+
+    compatRef.current.on('fold', persistDebounced);
+    compatRef.current.on('unfold', persistDebounced);
+    cleanupRef.current.persist = () => {
+      compatRef.current?.off('fold', persistDebounced);
+      compatRef.current?.off('unfold', persistDebounced);
+      persistDebounced.cancel?.();
+    };
+  }, [collection, containScroll, docKeyProp, enableBrunoVarInfo, initialScroll, item, mode, onScroll, persistenceScope, readOnly, scriptType, aiPreferences, showHintsFor, variables]);
+
+  const handleChange = useCallback((newValue) => {
+    cachedRef.current = newValue;
+    onEdit?.(newValue);
+  }, [onEdit]);
+
+  useEffect(() => {
+    onSearchBarVisibilityChange?.(searchBarVisible);
+  }, [searchBarVisible, onSearchBarVisibilityChange]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const newDocKey = docKeyProp || getDocKey({ docKey: docKeyProp, item, collection, mode, readOnly });
+    const docKeyChanged = newDocKey !== currentDocKeyRef.current;
+
+    if (docKeyChanged) {
+      if (currentDocKeyRef.current) {
+        writePersistedEditorState({
+          scope: persistenceScope,
+          key: currentDocKeyRef.current,
+          state: captureEditorState6(view)
+        });
       }
+      currentDocKeyRef.current = newDocKey;
+      cachedRef.current = String(value ?? '');
+      applyEditorState6(view, readPersistedEditorState({ scope: persistenceScope, key: newDocKey }), cachedRef.current);
+    } else if (value !== cachedRef.current) {
+      const compat = compatRef.current;
+      if (compat) {
+        const cursor = compat.getCursor();
+        compat.setValue(String(value ?? ''));
+        compat.setCursor(cursor);
+        writePersistedEditorState({ scope: persistenceScope, key: currentDocKeyRef.current, state: null });
+      }
+      cachedRef.current = String(value ?? '');
     }
-  };
-}
+  }, [value, mode, readOnly, docKeyProp, item, collection, persistenceScope]);
 
-const CodeEditorWithPersistenceScope = React.forwardRef((props, ref) => {
+  useEffect(() => {
+    return () => {
+      if (onScroll) {
+        onScroll(lastScrollRef.current);
+      }
+      if (currentDocKeyRef.current && viewRef.current) {
+        writePersistedEditorState({
+          scope: persistenceScope,
+          key: currentDocKeyRef.current,
+          state: captureEditorState6(viewRef.current)
+        });
+      }
+      cleanupRef.current.autocomplete?.();
+      cleanupRef.current.linkAware?.();
+      cleanupRef.current.lintTooltip?.();
+      cleanupRef.current.resize?.();
+      cleanupRef.current.varInfo?.();
+      cleanupRef.current.ai?.();
+      cleanupRef.current.persist?.();
+      if (searchBarVisible) {
+        onSearchBarVisibilityChange?.(false);
+      }
+    };
+  }, [onScroll, onSearchBarVisibilityChange, persistenceScope, searchBarVisible]);
+
+  return (
+    <StyledWrapper
+      className={`h-full w-full flex flex-col relative graphiql-container ${readOnly ? 'read-only' : ''} ${searchBarVisible ? 'search-bar-visible' : ''}`}
+      aria-label="Code Editor"
+      data-testid={testId}
+      font={font}
+      fontSize={fontSize}
+    >
+      <CodeMirrorSearch6
+        ref={searchBarRef}
+        visible={searchBarVisible}
+        view={viewRef.current}
+        readOnly={readOnly}
+        onClose={() => setSearchBarVisible(false)}
+      />
+      <div className="editor-container" style={{ height: '100%', width: '100%' }}>
+        <BrunoCodeEditor
+          ref={handleViewRef}
+          value={value}
+          mode={mode}
+          theme={theme}
+          readOnly={readOnly}
+          onChange={handleChange}
+          preset={PRESETS.FULL}
+          font={font}
+          fontSize={fontSize}
+          enableLint={Boolean(value?.trim())}
+          extraExtensions={extraExtensions}
+          style={{ height: '100%' }}
+        />
+      </div>
+    </StyledWrapper>
+  );
+});
+
+const CodeEditorWithPersistenceScope = forwardRef((props, ref) => {
   const persistenceScope = usePersistenceScope();
   const aiPreferences = useSelector((state) => state.app.preferences?.ai);
   return (

--- a/packages/bruno-app/src/hooks/useFocusErrorLine/index.js
+++ b/packages/bruno-app/src/hooks/useFocusErrorLine/index.js
@@ -2,19 +2,10 @@ import { useEffect, useRef } from 'react';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
 import { clearFocusErrorLine } from 'providers/ReduxStore/slices/tabs';
-import { focusErrorLine } from 'utils/codemirror/focusErrorLine';
+import { focusErrorLine } from 'utils/codemirror6/extensions/focusErrorLine';
 
 /**
  * Subscribes a CodeMirror-hosting component to the tab's `focusErrorLine` signal.
- * When the signal targets this host's `scriptPhase`, scrolls the editor to the
- * line and flashes a red highlight that fades over ~3s. Re-firing for the same
- * line is handled via the `requestedAt` token.
- *
- * @param {object} params
- * @param {string} params.uid                        Tab uid (request/folder/collection uid)
- * @param {React.RefObject} params.editorRef         Ref to a CodeEditor component (exposes `.editor`)
- * @param {string} params.scriptPhase               'pre-request' | 'post-response' | 'test'
- * @param {boolean} [params.isVisible=true]          Whether this editor's tab is currently shown
  */
 export const useFocusErrorLine = ({ uid, editorRef, scriptPhase, isVisible = true }) => {
   const dispatch = useDispatch();
@@ -27,24 +18,23 @@ export const useFocusErrorLine = ({ uid, editorRef, scriptPhase, isVisible = tru
 
   useEffect(() => {
     if (!focusErrorLineState || !isVisible) return;
-
     if (focusErrorLineState.scriptPhase !== scriptPhase) return;
 
     const timer = setTimeout(() => {
-      const editor = editorRef.current?.editor;
-      if (!editor) return;
+      const compat = editorRef.current?.editor;
+      if (!compat) return;
 
       if (disposeRef.current) {
         disposeRef.current();
         disposeRef.current = null;
       }
 
-      disposeRef.current = focusErrorLine(editor, focusErrorLineState.line);
+      disposeRef.current = focusErrorLine(compat, focusErrorLineState.line);
       dispatch(clearFocusErrorLine({ uid }));
     }, 0);
 
     return () => clearTimeout(timer);
-  }, [focusErrorLineState?.requestedAt, focusErrorLineState?.line, focusErrorLineState?.scriptPhase, isVisible, scriptPhase, uid]);
+  }, [focusErrorLineState?.requestedAt, focusErrorLineState?.line, focusErrorLineState?.scriptPhase, isVisible, scriptPhase, uid, dispatch, editorRef]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- Migrate main `CodeEditor` (scripts, pre/post-request) to BrunoCodeEditor
- Port persistence, AI ghost text, search, and `useFocusErrorLine`

## Test plan
- [ ] Edit pre-request and post-response scripts
- [ ] Test search, scroll persistence, and lint tooltips